### PR TITLE
fix image upload when there's a form error

### DIFF
--- a/app/controllers/bloak/admin/images_controller.rb
+++ b/app/controllers/bloak/admin/images_controller.rb
@@ -41,7 +41,7 @@ module Bloak
         if @image.save
           redirect_to(admin_images_path, notice: 'Image was successfully created.')
         else
-          render(:new)
+          render(:new, status: :unprocessable_entity)
         end
       end
 

--- a/app/views/bloak/admin/images/_form.html.erb
+++ b/app/views/bloak/admin/images/_form.html.erb
@@ -11,9 +11,7 @@
     </div>
   <% end %>
 
-
-
-  <% if image.image_file.attached? %>
+  <% if image.persisted? && image.image_file.attached? %>
     <h5 class="mt-3 mb-5">Current Image Preview</h5>
     <img src="<%= image.image_variant_url(resize_to_fit: [400, 400]) %>" alt="">
 


### PR DESCRIPTION
Minor issue.

When you try to upload an image with any empty form field it will cause and error when rendering `:new` again because the image is not persisted but it has an attached file.